### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,7 +11,7 @@ DTH_I2CKeypad	KEYWORD1
 ###########################################
 # Enum (constants)
 ###########################################
-NO_KEY LITERAL1
+NO_KEY	LITERAL1
 IDLE	LITERAL1
 PRESSED	LITERAL1
 HOLD	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords